### PR TITLE
fix image shrank after rotation

### DIFF
--- a/imageeditlibrary/src/main/java/com/xinlan/imageeditlibrary/editimage/fragment/RotateFragment.java
+++ b/imageeditlibrary/src/main/java/com/xinlan/imageeditlibrary/editimage/fragment/RotateFragment.java
@@ -196,8 +196,6 @@ public class RotateFragment extends BaseEditFragment {
             RectF dst = new RectF(left, top, left + originBit.getWidth(), top
                     + originBit.getHeight());
             canvas.save();
-            canvas.scale(mRotatePanel.getScale(), mRotatePanel.getScale(),
-                    imageRect.width() / 2, imageRect.height() / 2);
             canvas.rotate(mRotatePanel.getRotateAngle(), imageRect.width() / 2,
                     imageRect.height() / 2);
 


### PR DESCRIPTION
![screenshot_20171121-180506](https://user-images.githubusercontent.com/22448703/33070869-6cf67f7a-cef4-11e7-832d-bdcebd5365ef.jpg)

After rotation:

![screenshot_20171121-180520](https://user-images.githubusercontent.com/22448703/33070876-7178dc28-cef4-11e7-96db-9eaab59ad680.jpg)

The image shrank and left blank on the side:

![screenshot_20171121-180610](https://user-images.githubusercontent.com/22448703/33070949-a5a6bab0-cef4-11e7-8b13-e1bcfd74ced3.jpg)
